### PR TITLE
refacto: remove deprecated sensio/framework-extra-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "openai-php/client": "^0.10.3",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpdoc-parser": "^1.15",
-        "sensio/framework-extra-bundle": "^6.2",
         "symfony/console": "6.2.*",
         "symfony/dotenv": "6.2.*",
         "symfony/flex": "^2",

--- a/config/packages/sensio_framework_extra.yaml
+++ b/config/packages/sensio_framework_extra.yaml
@@ -1,3 +1,0 @@
-sensio_framework_extra:
-    router:
-        annotations: false


### PR DESCRIPTION
  * useless, no use of: @Route, @ParamConverter, @IsGranted, @Security,	@Template

command used: composer remove sensio/framework-extra-bundle

https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html

draft: wait for previous branch, then composer update to regenerate `composer.lock `

---
avant ce refacto:
<img width="716" height="360" alt="image" src="https://github.com/user-attachments/assets/9f1eebc9-d1b1-4013-8c23-9deffa05b07c" />

après ce refacto:
<img width="718" height="340" alt="image" src="https://github.com/user-attachments/assets/ac387bfe-d055-4a45-8209-033055aeb7b8" />
