### PR TITLE
fix: Déplacement du champ Film:date vers Proposition:date

### DIFF
--- a/migrations/Version20250808183554.php
+++ b/migrations/Version20250808183554.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250808183554 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE proposition ADD date DATETIME');
+        
+        // Copie des données depuis film vers proposition
+        $this->addSql('
+            UPDATE proposition p
+            JOIN film f ON p.film_id = f.id
+            SET p.date = f.date
+        ');
+
+        $this->addSql('ALTER TABLE proposition CHANGE date date DATETIME NOT NULL');
+        
+        // ⚠️ remove existing date column and data
+        $this->addSql('ALTER TABLE film DROP date');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE film ADD date DATE NOT NULL');
+
+        // Copie des données depuis proposition vers film 
+        $this->addSql('
+            UPDATE proposition p
+            JOIN film f ON p.film_id = f.id
+            SET f.date = p.date
+        ');
+
+        $this->addSql('ALTER TABLE proposition DROP date');
+    }
+}

--- a/src/Controller/FilmController.php
+++ b/src/Controller/FilmController.php
@@ -65,7 +65,6 @@ class FilmController extends AbstractController
     {
         $newFilm = $serializer->deserialize($request->getContent(), Film::class, 'json');
         $currentFilm->setTitre($newFilm->getTitre());
-        $currentFilm->setDate($newFilm->getDate());
         $currentFilm->setSortieFilm($newFilm->getSortieFilm());
         $currentFilm->setImdb($newFilm->getImdb());
 

--- a/src/Controller/PropositionController.php
+++ b/src/Controller/PropositionController.php
@@ -6,6 +6,7 @@ use OpenApi\Attributes as OA;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenAI;
 use DateTime;
+use DateTimeImmutable;
 use App\Entity\Film;
 use App\Entity\Semaine;
 use App\Entity\Proposition;
@@ -53,7 +54,6 @@ class PropositionController extends AbstractController
 
         $film = new Film();
         $film->setTitre($array_request['titre_film']);
-        $film->setDate(new DateTime());
         $film->setSortieFilm($array_request['sortie_film']);
         $film->setImdb($array_request['imdb_film'] );
 
@@ -61,6 +61,7 @@ class PropositionController extends AbstractController
         $proposition->setSemaine($currentSemaine->getCurrentSemaine($semaineRepository));
         $proposition->setFilm($film);
         $proposition->setScore(36);
+        $proposition->setDate(new DateTimeImmutable('now', new \DateTimeZone('UTC')));
 
         $em->persist($film);
         $em->persist($proposition);
@@ -212,7 +213,6 @@ class PropositionController extends AbstractController
                 // Créer une nouvelle instance de Film avec les mêmes données
                 $new_film = new Film();
                 $new_film->setTitre($film_existante->getTitre());
-                $new_film->setDate(new \DateTime()); // Par exemple, la date d'aujourd'hui
                 $new_film->setSortieFilm($film_existante->getSortieFilm());
                 $new_film->setImdb($film_existante->getImdb());
 
@@ -223,6 +223,7 @@ class PropositionController extends AbstractController
                 $new_proposition->setSemaine($semaine_courante);
                 $new_proposition->setFilm($new_film);
                 $new_proposition->setScore(36);
+                $new_proposition->setDate(new DateTime('now', new \DateTimeZone('UTC')));
 
                 $entityManager->persist($new_proposition);
 
@@ -367,7 +368,6 @@ class PropositionController extends AbstractController
                 $film->setTitre($titre_film);
                 $film->setImdb($lien_imdb);
                 $film->setSortieFilm((int)$sortie_film);
-                $film->setDate(new DateTime());
 
                 // Enregistrer le film en base de données
                 $em->persist($film);
@@ -377,6 +377,7 @@ class PropositionController extends AbstractController
                 $proposition->setSemaine($currentSemaine);
                 $proposition->setFilm($film);
                 $proposition->setScore(36);
+                $proposition->setDate(new DateTime('now', new \DateTimeZone('UTC')));
 
                 // Enregistrer la proposition en base de données
                 $em->persist($proposition);

--- a/src/Controller/SemaineController.php
+++ b/src/Controller/SemaineController.php
@@ -311,7 +311,6 @@ class SemaineController extends AbstractController
 
             $film = new Film();
             $film->setTitre($array_request['droit_divin_titre_film']);
-            $film->setDate(new DateTime());
             $film->setSortieFilm($array_request['droit_divin_date_film']);
             $film->setImdb($array_request['droit_divin_lien_imdb'] );
         

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -96,7 +96,6 @@ class AppFixtures extends Fixture
             //Création film Thor
             $film_thor = new Film();
             $film_thor->setTitre("Thor");
-            $film_thor->setDate(new \DateTime('2022-01-01'));
             $film_thor->setSortiefilm("2020");
             $film_thor->setImdb("https://www.imdb.com/title/tt10648342/");
             $manager->persist($film_thor);
@@ -105,7 +104,6 @@ class AppFixtures extends Fixture
             //Création film Iron Man
             $film_iron_man = new Film();
             $film_iron_man->setTitre("Iron_man");
-            $film_iron_man->setDate(new \DateTime('2023-01-30'));
             $film_iron_man->setSortiefilm("2014");
             $film_iron_man->setImdb("https://www.imdb.com/title/tt10648342/");
             $manager->persist($film_iron_man);
@@ -113,7 +111,6 @@ class AppFixtures extends Fixture
             //Création film Iron Man
             $film_hulk = new Film();
             $film_hulk->setTitre("Hulk");
-            $film_hulk->setDate(new \DateTime('2023-01-30'));
             $film_hulk->setSortiefilm("2014");
             $film_hulk->setImdb("https://www.imdb.com/title/tt10648342/");
             $manager->persist($film_hulk);

--- a/src/Entity/Film.php
+++ b/src/Entity/Film.php
@@ -27,10 +27,6 @@ class Film
     #[Groups(["getPropositions", "filmsGagnants"])]
     private ?string $titre = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE)]
-    #[Groups(["getPropositions", "filmsGagnants"])]
-    private ?\DateTimeInterface $date = null;
-
     #[ORM\Column]
     #[Groups(["getPropositions", "filmsGagnants"])]
     private ?int $sortie_film = null;
@@ -72,18 +68,6 @@ class Film
     public function setTitre(string $titre): self
     {
         $this->titre = $titre;
-
-        return $this;
-    }
-
-    public function getDate(): ?\DateTimeInterface
-    {
-        return $this->date;
-    }
-
-    public function setDate(\DateTimeInterface $date): self
-    {
-        $this->date = $date;
 
         return $this;
     }

--- a/src/Entity/Proposition.php
+++ b/src/Entity/Proposition.php
@@ -30,6 +30,10 @@ class Proposition
     #[Groups(["filmsGagnants"])]
     private ?Semaine $semaine = null;
 
+    #[ORM\Column(type: 'datetime_immutable', nullable: false)]
+    #[Groups(["getPropositions", "filmsGagnants"])]
+    private ?\DateTimeInterface $date = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -71,4 +75,15 @@ class Proposition
         return $this;
     }
 
+    public function getDate(): ?\DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function setDate(\DateTimeInterface $date): self
+    {
+        $this->date = $date;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Le champ `date` de la table `Film` est utilisé actuellement pour stocker la date de la proposition (voir screenshots ci-dessous).

Pour plus de cohérence il faudrait déplacer ce champ dans la table `Proposition`

resultat:
<img width="512" height="404" alt="image" src="https://github.com/user-attachments/assets/5ba02a68-9fd6-42ac-ba13-c7f9ee2159bf" />


draft:
  * touche aux dates comme d'autres branches, mieux vaut rebaser après
  * necessite de jouer le script de migration