### PR TITLE
Feature: securisation membres password

### DIFF
--- a/migrations/Version20250926142806.php
+++ b/migrations/Version20250926142806.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250926142806 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_F6B4FB295126AC48 ON membre (mail)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_F6B4FB295126AC48 ON membre');
+    }
+}

--- a/src/Controller/MembreController.php
+++ b/src/Controller/MembreController.php
@@ -2,6 +2,9 @@
 
 namespace App\Controller;
 
+use App\DTO\Membres\MemberLoginError;
+use App\DTO\Membres\MemberLoginRequest;
+use App\DTO\Membres\MemberLoginSuccess;
 use OpenApi\Attributes as OA;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use App\Entity\Membre;
@@ -11,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
@@ -150,4 +154,67 @@ class MembreController extends AbstractController
         $jsonProposition = $serializer->serialize($membre, 'json', ['groups' => 'getPropositions']); 
         return new JsonResponse($jsonProposition, Response::HTTP_OK, [], true);
     }
+
+
+    #[OA\Tag(name: "Membre")]
+    #[OA\Post(
+        path: "/api/membre_login_check",
+        summary: "Vérifie les identifiants d’un membre",
+        requestBody: new OA\RequestBody(
+            description: "Update membre activation status",
+            required: true,
+            content: new OA\JsonContent(ref: new Model(type: MemberLoginRequest::class))
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "Connexion réussie",
+                content: new OA\JsonContent(ref: new Model(type: MemberLoginSuccess::class))
+            ),
+            new OA\Response(
+                response: 400,
+                description: "Paramètres manquants",
+                content: new OA\JsonContent(ref: new Model(type: MemberLoginError::class))
+            ),
+            new OA\Response(
+                response: 401,
+                description: "Identifiants invalides",
+                content: new OA\JsonContent(ref: new Model(type: MemberLoginError::class))
+            )
+        ]
+    )]
+    #[Route('/api/membre_login_check', name: 'membre_login_check', methods: ['POST'])]
+    public function loginCheck(Request $request, MembreRepository $membreRepository, SerializerInterface $serializer, ValidatorInterface $validator): JsonResponse
+    {
+        $body = $serializer->deserialize($request->getContent(), MemberLoginRequest::class, 'json');
+
+        // validation
+        $errors = $validator->validate($body);
+
+        if (count($errors) > 0) {
+            return $this->json([
+                'error' => 'Validation failed',
+                'details' => (string) $errors
+            ], 400);
+        }
+
+        // get the member
+        $membre = $membreRepository->findOneBy(['mail' => $body->email]);
+
+        if (!$membre) {
+            return new JsonResponse(['error' => 'Identifiants invalides'], 401);
+        }
+
+        // check password
+        if ($body->password !== $membre->getMdp()) {
+            return new JsonResponse(['error' => 'Identifiants invalides'], 401);
+        }
+
+        $reponse = new MemberLoginSuccess();
+        $reponse->membre_id = $membre->getId();
+        $reponse->email = $membre->getMail();
+
+        return $this->json($reponse);
+    }
+
 }

--- a/src/Controller/MembreController.php
+++ b/src/Controller/MembreController.php
@@ -27,8 +27,7 @@ class MembreController extends AbstractController
                 response: 200,
                 description: "Successful response",
                 content: new OA\JsonContent(
-                    type: "array",
-                    items: new OA\Items(ref: new Model(type: Membre::class))
+                    ref: new Model(type: Membre::class, groups: ['membre:read'])
                 )
             ),
             new OA\Response(
@@ -47,7 +46,7 @@ class MembreController extends AbstractController
 
         $membreList = $membreRepository->findAll();
 
-        $jsonMembreList = $serializer->serialize($membreList, 'json');
+        $jsonMembreList = $serializer->serialize($membreList, 'json', ['groups' => 'membre:read']);
         return new JsonResponse($jsonMembreList, Response::HTTP_OK, [], true);
     }
 
@@ -70,7 +69,9 @@ class MembreController extends AbstractController
             new OA\Response(
                 response: 200,
                 description: "Membre details retrieved successfully",
-                content: new OA\JsonContent(ref: new Model(type: Membre::class))
+                content: new OA\JsonContent(
+                    ref: new Model(type: Membre::class, groups: ['membre:read'])
+                )
             ),
             new OA\Response(
                 response: 404,
@@ -84,7 +85,7 @@ class MembreController extends AbstractController
 
         $membre = $membreRepository->find($id);
         if($membre) {
-            $jsonMembre = $serializer->serialize($membre, 'json');
+            $jsonMembre = $serializer->serialize($membre, 'json', ['groups' => 'membre:read']);
             return new JsonResponse($jsonMembre, Response::HTTP_OK, [], true);
         }
         return new JsonResponse(null, Response::HTTP_NOT_FOUND);

--- a/src/DTO/Membres/MemberLoginError.php
+++ b/src/DTO/Membres/MemberLoginError.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\DTO\Membres;
+
+
+class MemberLoginError
+{
+    public string $error;
+}

--- a/src/DTO/Membres/MemberLoginRequest.php
+++ b/src/DTO/Membres/MemberLoginRequest.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\DTO\Membres;
+
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MemberLoginRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    public string $email;
+
+
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 4)]
+    public string $password;
+}

--- a/src/DTO/Membres/MemberLoginSuccess.php
+++ b/src/DTO/Membres/MemberLoginSuccess.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\DTO\Membres;
+
+
+class MemberLoginSuccess
+{
+    public int $membre_id;
+
+    public string $email;
+}

--- a/src/Entity/Membre.php
+++ b/src/Entity/Membre.php
@@ -27,7 +27,7 @@ class Membre
     private ?string $prenom = null;
 
     #[Groups(['membre:read'])]
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, unique: true)]
     private ?string $mail = null;
 
     #[ORM\Column(length: 255)]

--- a/src/Entity/Membre.php
+++ b/src/Entity/Membre.php
@@ -15,23 +15,25 @@ class Membre
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    #[Groups(["getPropositions", "filmsGagnants", 'preselection:read'])]
+    #[Groups(['membre:read', "getPropositions", "filmsGagnants", 'preselection:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(["getPropositions", "filmsGagnants", "postMembre"])]
+    #[Groups(['membre:read', "getPropositions", "filmsGagnants", "postMembre"])]
     private ?string $nom = null;
 
-    #[Groups(["getPropositions", "postMembre"])]
+    #[Groups(['membre:read', "getPropositions", "postMembre"])]
     #[ORM\Column(length: 255)]
     private ?string $prenom = null;
 
+    #[Groups(['membre:read'])]
     #[ORM\Column(length: 255)]
     private ?string $mail = null;
 
     #[ORM\Column(length: 255)]
     private ?string $mdp = null;
 
+    #[Groups(['membre:read'])]
     #[ORM\Column]
     private ?bool $actif = null;
 


### PR DESCRIPTION

Actuellement, les 2 endpoints suivant renvoient le mdp membre
- /api/membres/{id}
- /api/membres/

voila le resultat apres ce dev :
le champ "mdp" n'est plus present

<img width="300" height="603" alt="image" src="https://github.com/user-attachments/assets/5825b025-a6d5-4add-92e5-faec246156fe" />

Pour permettre au client front de s'authentifier et d'identifier un membre, l'API propose un nouvel endpoint:

POST /api/membre_login_check
{
    "email" : "xx@xxx.xxx",
    "password" : "xxxx"
}

