### PR TITLE
feature: add support for vote deadline

### DIFF
--- a/.env
+++ b/.env
@@ -36,3 +36,12 @@ JWT_PASSPHRASE=***
 
 ###> OpenAI KEY ###
 OPENAI_KEY=***
+
+###> vote deadline ###
+# VOTE_DEADLINE_DAY: day name. ex.  mon | tue | wed | thu | fri | sat | sun 
+VOTE_DEADLINE_DAY=fri
+# VOTE_DEADLINE_TIME: hour and minutes. example 18:00
+VOTE_DEADLINE_TIME=18:00
+# VOTE_DEADLINE_TZ: timezone identifier. ex. Europe/Paris
+VOTE_DEADLINE_TZ=Europe/Paris
+###< vote date range ###

--- a/src/Entity/Semaine.php
+++ b/src/Entity/Semaine.php
@@ -229,4 +229,31 @@ class Semaine
         $this->isVoteTermine = $isVoteTermine;
         return $this;
     }
+
+    // Renvoie la date et l'heure de la deadline du vote de cette semaine.
+    // Le lendemain de la deadline commence la semaine suivante.
+    // TODO: utiliser un groupe nommé 'semaine:read' serait plus clair que 'getPropositions'
+    #[SerializedName('vote_deadline')]
+    #[Groups(['getPropositions'])]
+    public function getVoteDeadline(): \DateTimeImmutable
+    {
+        $day = $_ENV['VOTE_DEADLINE_DAY'] ?? 'Fri';
+        $time = $_ENV['VOTE_DEADLINE_TIME'] ?? '18:00';
+        $tz = $_ENV['VOTE_DEADLINE_TZ'] ?? 'UTC';
+    
+        // 1 - creé une date "now" avec la timezone souhaitée
+        // 2 - si le jour souhaité n'est pas aujourd'hui, ajoute des jours
+        // 3 - fixe l'heure souhaitée
+        // peut être aujourd'hui (possiblement avant l'heure en cours), ou dans le futur
+        return new \DateTimeImmutable("$day $time", new \DateTimeZone($tz));
+    }
+
+
+    // Verifie si la plage temporelle de vote est achevée
+    public function hasVoteDeadlinePassed(): bool {
+        $tz = $_ENV['VOTE_DEADLINE_TZ'] ?? 'UTC';
+        $now = new \DateTimeImmutable("now", new \DateTimeZone($tz));
+        
+        return $this->getVoteDeadline() < $now;
+    }
 }

--- a/src/Service/CurrentSemaine.php
+++ b/src/Service/CurrentSemaine.php
@@ -59,6 +59,12 @@ class CurrentSemaine
             return null; // Semaine non trouvée
         }   
 
+        // Vérifie si la plage temporelle de vote est terminée
+        if ($currentSemaine->hasVoteDeadlinePassed()) {
+            return true;
+        }
+
+        // Vérifie si les membres actifs ont tous votés
         $idCurrentSemaine = $currentSemaine->getId();
 
         $votantsCount = $this->em->createQueryBuilder()
@@ -77,7 +83,7 @@ class CurrentSemaine
         ->getQuery()
         ->getSingleScalarResult();
 
-        // les ayant voté + le proposeur 
+        // compare les ayant voté + le proposeur au nombre de membres actifs
         $vote_termine_cette_semaine = (($votantsCount + 1) === $membreActifCount);
 
         return $vote_termine_cette_semaine;


### PR DESCRIPTION
- La config de la deadline des vote se fait dans le fichier .env
- L'entity semaine a une méthode supplémentaire pour calculer la deadline sur la base de la config
- Le endpoint current semaine contient un champ supplémentaire: vote_deadline
- la propriété "is_vote_termine" verifie dorenavant si la plage de vote n'est pas passée

----

**Principe de la période de vote**
<img width="400" height="741" alt="image" src="https://github.com/user-attachments/assets/f4b8331b-4223-470f-896e-ee7b7dca203d" />

-----

**Resultat**
<img width="400" height="747" alt="image" src="https://github.com/user-attachments/assets/cf916a3c-d42a-483c-a350-23281973462b" />
